### PR TITLE
Remove .phpunit.result.cache from Git VCS

### DIFF
--- a/.phpunit.result.cache
+++ b/.phpunit.result.cache
@@ -1,1 +1,0 @@
-C:37:"PHPUnit\Runner\DefaultTestResultCache":44:{a:2:{s:7:"defects";a:0:{}s:5:"times";a:0:{}}}


### PR DESCRIPTION
The `.phpunit.result.cache` is generated by `PHPUnit 8.x` version.

And above cached file should be removed from Git version control.